### PR TITLE
Looser stream check

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -23,7 +23,7 @@ function send(method: any, url?: any, options?: Options, payload?: any): Promise
 
     // Send the payload down the wire, if present and applicable
 
-    if (payload && req.writable && payload instanceof Readable) {
+    if (payload && req.writable && (payload instanceof Readable || payload.on)) {
       payload.pipe(req)
     } else if (payload && req.writable) {
       if (typeof payload != 'string') {


### PR DESCRIPTION
I found that your `payload instanceof Readable` check was too strict for use with streams produced by [node-archiver](https://github.com/archiverjs/node-archiver). I loosened the check to see if the `.on` method typically present on streams exists. This works for my purposes, but it has the potential to break.

If you'd like to tighten this up, please do, but for now this change works for most stream use cases.